### PR TITLE
feat: add dark mode support on Android + Documentation updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,28 +23,22 @@ The [example app](/example/) demonstrates usage of the library. You need to run 
 
 It is configured to use the local version of the library, so any changes you make to the library's source code will be reflected in the example app. Changes to the library's JavaScript code will be reflected in the example app without a rebuild, but native code changes will require a rebuild of the example app.
 
-If you want to use Android Studio or XCode to edit the native code, you can open the `example/android` or `example/ios` directories respectively in those editors. To edit the Objective-C or Swift files, open `example/ios/EmojiPopupExample.xcworkspace` in XCode and find the source files at `Pods > Development Pods > react-native-emoji-popup`.
+For development, you need to use the official IDEs:
 
-To edit the Java or Kotlin files, open `example/android` in Android studio and find the source files at `react-native-emoji-popup` under `Android`.
+For iOS:
+- Open `example/ios/EmojiPopupExample.xcworkspace` in Xcode
+- Navigate to `Pods > Development Pods > react-native-emoji-popup` to find the Objective-C/Swift source files
 
-You can use various commands from the root directory to work with the project.
+For Android:
+- Open `example/android` in Android Studio
+- Find the source files under `react-native-emoji-popup` in the Android view
+
+Using these IDEs is recommended as they provide the proper development environment, debugging tools, and ensure compatibility with the native platforms.
 
 To start the packager:
 
 ```sh
 yarn example start
-```
-
-To run the example app on Android:
-
-```sh
-yarn example android
-```
-
-To run the example app on iOS:
-
-```sh
-yarn example ios
 ```
 
 To confirm that the app is running with the new architecture, you can check the Metro logs for a message like this:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,26 @@
-# `react-native-emoji-popup` 🌈
+<h1 align="center">
+  react-native-emoji-popup 🌈
+</h1>
 
-Emoji Popup for React Native, using native primitives. [MCEmojiPicker](https://github.com/izyumkin/MCEmojiPicker) on iOS and [Emoji2](https://developer.android.com/jetpack/androidx/releases/emoji2) on Android.
+<p align="center">
+  <strong>Emoji Popup for React Native, using native primitives.
+</strong><br>
+</p>
+
+<div align="center">
+
+[![mit licence](https://img.shields.io/dub/l/vibe-d.svg?style=for-the-badge)](https://github.com/okwasniewski/react-native-emoji-popup/blob/main/LICENSE)
+[![npm version](https://img.shields.io/npm/v/react-native-emoji-popup?style=for-the-badge)](https://www.npmjs.org/package/react-native-bottom-tabs)
+[![npm downloads](https://img.shields.io/npm/dt/react-native-emoji-popup.svg?style=for-the-badge)](https://www.npmjs.org/package/react-native-bottom-tabs)
+[![npm downloads](https://img.shields.io/npm/dm/react-native-emoji-popup.svg?style=for-the-badge)](https://www.npmjs.org/package/react-native-bottom-tabs)
+</div>
 
 https://github.com/user-attachments/assets/a6f94dc5-6175-419c-a6e4-04ef48aaf913
 
 ## Installation
 
 ```sh
-npm install react-native-emoji-popup
+npm i react-native-emoji-popup
 ```
 
 ## Usage
@@ -61,6 +74,22 @@ export default function EmojiExample() {
 ```
 
 
+## Props
+
+| Prop | Type | Platform | Description | Default |
+|------|------|----------|-------------|---------|
+| `children` | `React.ReactNode` | iOS, Android | The component that will trigger the emoji picker when pressed | - |
+| `onEmojiSelected` | `(emoji: string) => void` | iOS, Android | Callback function that receives the selected emoji as a parameter | - |
+| `closeButton` | `(props: { close: () => void }) => React.ReactNode` | Android | Custom close button component that receives a close function | Default close button |
+| `contentContainerStyle` | `StyleProp<ViewStyle>` | Android | Style object for customizing the emoji picker container appearance | - |
+| `style` | `StyleProp<ViewStyle>` | iOS, Android | Style object for the trigger component container | - |
+
+## Features
+
+### Dark Mode Support
+
+The emoji picker automatically adapts to the device's color scheme on both platforms. On Android, you can customize the color scheme by passing a `contentContainerStyle` prop to the `EmojiPopup` component and specifying the `backgroundColor` property.
+
 ## Contributing
 
 See the [contributing guide](CONTRIBUTING.md) to learn how to contribute to the repository and the development workflow.
@@ -71,7 +100,8 @@ MIT
 
 ## Acknowledgements
 
-- [MCEmojiPicker](https://github.com/izyumkin/MCEmojiPicker)
+- [MCEmojiPicker](https://github.com/izyumkin/MCEmojiPicker) - underlying iOS library.
+- [Emoji2](https://developer.android.com/jetpack/androidx/releases/emoji2) - underlying Android library.
 
 ---
 

--- a/android/src/main/java/com/emojipopup/EmojiPopupView.kt
+++ b/android/src/main/java/com/emojipopup/EmojiPopupView.kt
@@ -1,15 +1,21 @@
 package com.emojipopup
 
 import android.content.Context
+import android.content.res.Configuration
 import android.widget.FrameLayout
 import androidx.annotation.UiThread
 import androidx.emoji2.emojipicker.EmojiPickerView
 
 class EmojiPopupView(context: Context) : FrameLayout(context) {
-  private var emojiPickerView = EmojiPickerView(context)
+  private lateinit var emojiPickerView: EmojiPickerView
   var onEmojiSelectedListener: ((emoji: String) -> Unit)? = null
 
   init {
+    setupView()
+  }
+
+  private fun setupView() {
+    emojiPickerView = EmojiPickerView(context)
     addView(emojiPickerView, LayoutParams(
       LayoutParams.MATCH_PARENT,
       LayoutParams.MATCH_PARENT
@@ -32,5 +38,12 @@ class EmojiPopupView(context: Context) : FrameLayout(context) {
   override fun requestLayout() {
     super.requestLayout()
       post { measureAndLayout() }
+  }
+
+  override fun onConfigurationChanged(newConfig: Configuration?) {
+    super.onConfigurationChanged(newConfig)
+    // Re-add the view once the configuration changes.
+    removeView(emojiPickerView)
+    setupView()
   }
 }

--- a/src/EmojiPopup.android.tsx
+++ b/src/EmojiPopup.android.tsx
@@ -1,4 +1,11 @@
-import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import {
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  useColorScheme,
+  View,
+} from 'react-native';
 import EmojiPopupView from './EmojiPopupViewNativeComponent';
 import { useState } from 'react';
 import type { EmojiPopupProps } from './types';
@@ -7,10 +14,14 @@ const EmojiModal = ({
   children,
   onEmojiSelected,
   closeButton,
+  contentContainerStyle,
 }: EmojiPopupProps) => {
   const [modalVisible, setModalVisible] = useState(false);
+  const colorScheme = useColorScheme();
 
   const close = () => setModalVisible(false);
+
+  const backgroundColor = colorScheme === 'dark' ? '#000' : '#fff';
 
   return (
     <>
@@ -22,7 +33,15 @@ const EmojiModal = ({
         visible={modalVisible}
         onRequestClose={() => setModalVisible(false)}
       >
-        <View style={styles.modalView}>
+        <View
+          style={[
+            {
+              backgroundColor,
+            },
+            styles.modalView,
+            contentContainerStyle,
+          ]}
+        >
           {closeButton ? (
             closeButton({ close })
           ) : (
@@ -55,7 +74,6 @@ const styles = StyleSheet.create({
   },
   modalView: {
     flex: 1,
-    backgroundColor: 'white',
     paddingTop: 50,
   },
   closeButton: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { StyleProp, ViewStyle } from 'react-native';
+
 type CloseButtonProps = {
   close: () => void;
 };
@@ -16,4 +18,10 @@ export interface EmojiPopupProps {
    * @platform android
    */
   closeButton?: (props: CloseButtonProps) => React.ReactNode;
+
+  /*
+   * Content container style.
+   * @platform android
+   */
+  contentContainerStyle?: StyleProp<ViewStyle>;
 }


### PR DESCRIPTION
This PR adds dark mode support on Android.

By default we set the background color of the Android modal to be either black or white. This can be customized by passing your own `contentContainerStyle`