### PR TITLE
iOS: add once-only tap gesture guard to avoid duplicate recognizers

### DIFF
--- a/ios/EmojiPopupView.swift
+++ b/ios/EmojiPopupView.swift
@@ -10,14 +10,14 @@ import React
 public class EmojiPopupViewImpl: UIView, MCEmojiPickerDelegate {
   private var delegate: EmojiPopupDelegate?
   @objc var onEmojiSelected: RCTDirectEventBlock?
-  private var didAddTapGesture: Bool = false
+  private var tapGesture: UITapGestureRecognizer?
   
-  public override func layoutSubviews() {
-    super.layoutSubviews()
-    if !didAddTapGesture {
-      let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
-      self.addGestureRecognizer(tapGesture)
-      didAddTapGesture = true
+  public override func didMoveToWindow() {
+    super.didMoveToWindow()
+    if tapGesture == nil {
+      let g = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
+      self.addGestureRecognizer(g)
+      tapGesture = g
     }
   }
   

--- a/ios/EmojiPopupView.swift
+++ b/ios/EmojiPopupView.swift
@@ -10,10 +10,15 @@ import React
 public class EmojiPopupViewImpl: UIView, MCEmojiPickerDelegate {
   private var delegate: EmojiPopupDelegate?
   @objc var onEmojiSelected: RCTDirectEventBlock?
+  private var didAddTapGesture: Bool = false
   
   public override func layoutSubviews() {
-    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
-    self.addGestureRecognizer(tapGesture)
+    super.layoutSubviews()
+    if !didAddTapGesture {
+      let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
+      self.addGestureRecognizer(tapGesture)
+      didAddTapGesture = true
+    }
   }
   
   @objc func handleTap(_ gesture: UITapGestureRecognizer) {

--- a/ios/EmojiPopupView.swift
+++ b/ios/EmojiPopupView.swift
@@ -15,9 +15,9 @@ public class EmojiPopupViewImpl: UIView, MCEmojiPickerDelegate {
   public override func didMoveToWindow() {
     super.didMoveToWindow()
     if tapGesture == nil {
-      let g = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
-      self.addGestureRecognizer(g)
-      tapGesture = g
+      let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
+      self.addGestureRecognizer(gestureRecognizer)
+      tapGesture = gestureRecognizer
     }
   }
   


### PR DESCRIPTION
Prevents multiple tap gesture recognizers from being attached to the trigger view on iOS. Adds a small boolean guard in EmojiPopupView.swift.

- iOS-only, no API changes
- Repro: Open picker repeatedly -> multiple recognizers fire
- After: single recognizer, expected behavior

Thanks!